### PR TITLE
Tailor GluCat Clifford algebra classes

### DIFF
--- a/source/GluCatFramedMulti/SpecializedAlgebra.hpp
+++ b/source/GluCatFramedMulti/SpecializedAlgebra.hpp
@@ -67,7 +67,18 @@ namespace gabenchmark {
 
 #endif
 
-    using multivector_t = framed_multi<real_t>;
+#if (GABENCHMARK_GLUCAT_POSITIVE_GENERATORS <= 4)
+    #define GABENCHMARK_GLUCAT_LO (-4)
+    #define GABENCHMARK_GLUCAT_HI (4)
+#elif (GABENCHMARK_GLUCAT_POSITIVE_GENERATORS <= 8)
+    #define GABENCHMARK_GLUCAT_LO (-8)
+    #define GABENCHMARK_GLUCAT_HI (8)
+#else
+    #define GABENCHMARK_GLUCAT_LO (DEFAULT_LO)
+    #define GABENCHMARK_GLUCAT_HI (DEFAULT_HI)
+#endif
+
+    using multivector_t = framed_multi<real_t, GABENCHMARK_GLUCAT_LO, GABENCHMARK_GLUCAT_HI>;
 
 }
 

--- a/source/GluCatMatrixMulti/SpecializedAlgebra.hpp
+++ b/source/GluCatMatrixMulti/SpecializedAlgebra.hpp
@@ -67,7 +67,18 @@ namespace gabenchmark {
 
 #endif
 
-    using multivector_t = matrix_multi<real_t>;
+#if (GABENCHMARK_GLUCAT_POSITIVE_GENERATORS <= 4)
+    #define GABENCHMARK_GLUCAT_LO (-4)
+    #define GABENCHMARK_GLUCAT_HI (4)
+#elif (GABENCHMARK_GLUCAT_POSITIVE_GENERATORS <= 8)
+    #define GABENCHMARK_GLUCAT_LO (-8)
+    #define GABENCHMARK_GLUCAT_HI (8)
+#else
+    #define GABENCHMARK_GLUCAT_LO (DEFAULT_LO)
+    #define GABENCHMARK_GLUCAT_HI (DEFAULT_HI)
+#endif
+
+    using multivector_t = matrix_multi<real_t, GABENCHMARK_GLUCAT_LO, GABENCHMARK_GLUCAT_HI>;
 
 }
 


### PR DESCRIPTION
Closes #5 
Tailor GluCat Clifford algebra classes to fit `GABENCHMARK_GLUCAT_POSITIVE_GENERATORS.`
This allows GluCat to use smaller `index_set<>` classes which might be faster, depending on compilers and the speed of various bit operations. 

I have tested using
```
$ uname -a
Linux operette 4.15.0-45-generic #48-Ubuntu SMP Tue Jan 29 16:28:13 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
$ g++-8 --version
g++-8 (Ubuntu 8.2.0-1ubuntu2~18.04) 8.2.0
```